### PR TITLE
Fix bug in SvgXmlRecursivelySetFill

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,8 @@ Svg.Use = Use;
 function SvgXmlRecursivelySetFill(node, fill) {
   if (!node) return;
   node.setAttribute('fill', fill);
-  node.children.forEach(nodeChild => SvgXmlRecursivelySetFill(nodeChild, fill))
+  const childArr = Array.from(node.children);
+  childArr.forEach(nodeChild => SvgXmlRecursivelySetFill(nodeChild, fill))
 }
 
 export class SvgXml extends React.Component {


### PR DESCRIPTION
On [line 104](https://github.com/shamilovtim/react-native-svgxml-web/blob/master/index.js#L104), node.children may be of type [HTMLCollection](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCollection), which does not have a forEach method. Calling the recursive function in this case will result in `type error: node.children.forEach is not a function`.

Creating an array from node.children will allow the forEach method to be called.